### PR TITLE
Use parent instead of getRelation, this way, if relation is not there…

### DIFF
--- a/src/Listeners/AddNodeInRanking.php
+++ b/src/Listeners/AddNodeInRanking.php
@@ -34,10 +34,10 @@ class AddNodeInRanking
      */
     protected function handle(): void
     {
-        if ($this->node->type === 'label' && $this->node->getRelation('parent') instanceof InputContract) {
+        if ($this->node->type === 'label' && $this->node->parent instanceof InputContract) {
             return;
         }
 
-        $this->node->getRelation('parent')->addInRanking($this->node);
+        $this->node->parent->addInRanking($this->node);
     }
 }


### PR DESCRIPTION
…, we query the parent resource and not throw a failure.